### PR TITLE
Enable custom template support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -101,6 +101,7 @@ def build_converter(mode = :pretty)
         basebackend: 'html',
         outfilesuffix: '.html',
         filetype: 'html',
+        supports_templates: true
       },
       engine_opts: {
         generator: generator,

--- a/asciidoctor-html5s.gemspec
+++ b/asciidoctor-html5s.gemspec
@@ -22,11 +22,11 @@ EOF
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_runtime_dependency 'asciidoctor', '~> 1.5.5'
+  s.add_runtime_dependency 'asciidoctor', '~> 1.5.7'
   s.add_runtime_dependency 'thread_safe', '~> 0.3.4'
 
   s.add_development_dependency 'asciidoctor-doctest', '= 2.0.0.beta.4'
-  s.add_development_dependency 'asciidoctor-templates-compiler', '~> 0.3.0'
+  s.add_development_dependency 'asciidoctor-templates-compiler', '~> 0.4.0'
   s.add_development_dependency 'bundler', '~> 1.6'
   s.add_development_dependency 'coderay', '~> 1.1'
   s.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Using the [newly-added] boolean parameters option in
asciidoctor-templates-compiler, this patch adds support for custom
templates. Since support for this option was added in Asciidoctor
[1.5.7], this locks the dependency to ~> 1.5.7.

[newly-added]: https://github.com/jirutka/asciidoctor-templates-compiler/pull/2/commits/fb507618dcc482e59d21d98dd258e2e9fc547aea
[1.5.7]: https://github.com/asciidoctor/asciidoctor/commit/ec8e7e002be41a12f79c2e2629ac7ea15103438a