### PR TITLE
add closing tag thead/tbody/tfoot to for table (#17)

### DIFF
--- a/data/templates/table.html.slim
+++ b/data/templates/table.html.slim
@@ -35,3 +35,4 @@
                       - else
                         - content.each do |text|
                           p =text
+        </t#{tblsec}>


### PR DESCRIPTION
This adds the closing tag thead/tbody/tfoot to for table 

The test suite didn't find this case as Nokogiri seems to add missing closing tags *after* conversion from AsciiDoc to HTML *before* comparing it with the expected result. 

I don't know how to change the Nokigiri behavior in asciidoctor-doctest; but I hope the PR fixes the table. 

fixes #17 